### PR TITLE
refactor: simplify route definitions by removing ROOT dependency and unused file

### DIFF
--- a/web/src/dimadon/inventory/Inventory.tsx
+++ b/web/src/dimadon/inventory/Inventory.tsx
@@ -2,6 +2,7 @@ import LoaderIcon from '@/components/icons/LoaderIcon'
 import { Input } from '@/components/ui/input'
 import TableKardex from '@/dimadon/inventory/components/TableKardex'
 import { useQueryAllKardexs } from '@/dimadon/inventory/hooks/useQueryAllKardexs'
+import { numberToCurrency } from '@/dimadon/utils/numberToCurrency'
 import { useDebounce } from '@/hooks/useDebounce'
 import { type IKardex } from '@/types'
 import { cn } from '@/utils/cn'
@@ -10,7 +11,6 @@ import { createColumnHelper } from '@tanstack/react-table'
 import { Fragment, useMemo, useState } from 'react'
 import { FaClipboardList, FaSearch } from 'react-icons/fa'
 import { FaArrowRightArrowLeft, FaTableCellsRowLock } from 'react-icons/fa6'
-import { numberToCurrency } from '../utils/numberToCurrency'
 
 const columnHelper = createColumnHelper<IKardex>()
 

--- a/web/src/dimadon/routes/admin.ts
+++ b/web/src/dimadon/routes/admin.ts
@@ -1,6 +1,4 @@
-import { ROOT } from "@/dimadon/routes/root";
-
-const ADMIN = `${ROOT}administracion`
+const ADMIN = '/administracion'
 
 export const ADMIN_ROUTES = {
   ROOT: `${ADMIN}`,

--- a/web/src/dimadon/routes/root.ts
+++ b/web/src/dimadon/routes/root.ts
@@ -1,1 +1,0 @@
-export const ROOT = '/'

--- a/web/src/dimadon/routes/session.ts
+++ b/web/src/dimadon/routes/session.ts
@@ -1,9 +1,7 @@
-import { ROOT } from "@/dimadon/routes/root";
-
-const INVENTORY = `${ROOT}inventario`
-const PRODUCTS = `${ROOT}productos`
-const MOVEMENTS = `${ROOT}movimientos`
-const USERS = `${ROOT}usuarios`
+const INVENTORY = 'inventario'
+const PRODUCTS = 'productos'
+const MOVEMENTS = 'movimientos'
+const USERS = 'usuarios'
 
 export const SESSION_ROUTES = {
   INVENTORY: {


### PR DESCRIPTION
This pull request includes updates to imports, route definitions, and utility usage in the `dimadon` module. The most important changes focus on optimizing imports and simplifying route management.

### Import Optimization:
* [`web/src/dimadon/inventory/Inventory.tsx`](diffhunk://#diff-212bc1ab50209cc13f895594e510478079974301b91938a7b1463d78f27fe6efR5): Updated the `numberToCurrency` import to use an absolute path (`@/dimadon/utils/numberToCurrency`) instead of a relative path, improving consistency and maintainability. [[1]](diffhunk://#diff-212bc1ab50209cc13f895594e510478079974301b91938a7b1463d78f27fe6efR5) [[2]](diffhunk://#diff-212bc1ab50209cc13f895594e510478079974301b91938a7b1463d78f27fe6efL13)

### Route Simplification:
* [`web/src/dimadon/routes/admin.ts`](diffhunk://#diff-78ab03a93854e9187a0f53ec7381ec69b8a4dcf718c2691715b3c08303aac805L1-R1): Removed dependency on the `ROOT` constant and directly defined the `ADMIN` route as `'/administracion'`.
* [`web/src/dimadon/routes/root.ts`](diffhunk://#diff-6489befe25d538c08758a1d7c3683a370f97e431a0052d5a9c4c01a75e2ed4d1L1): Removed the `ROOT` constant, simplifying the route structure.
* [`web/src/dimadon/routes/session.ts`](diffhunk://#diff-50c47de4943d8d4c4468c3502334adfbcd78a34af7cbd7353a5ddfd0ebf4bd60L1-R4): Replaced concatenated route definitions (e.g., `${ROOT}inventario`) with direct string literals for `INVENTORY`, `PRODUCTS`, `MOVEMENTS`, and `USERS`, simplifying the code.